### PR TITLE
removed 'e' from built-in constants (as it is sometimes used for reversal potential)

### DIFF
--- a/lib9ml/python/nineml/maths.py
+++ b/lib9ml/python/nineml/maths.py
@@ -12,7 +12,7 @@ import numpy
 from .exceptions import NineMLMathParseError
 
 
-_constants = set(['pi', 'e'])
+_constants = set(['pi'])
 
 _functions = set(['exp', 'sin', 'cos', 'log', 'log10', 'pow',
                   'sinh', 'cosh', 'tanh', 'sqrt', 'mod', 'sum',


### PR DESCRIPTION
This PR addresses issue #5
