### PR TITLE
Switched Ports from AnalogPort/EventPort to AnalogSendPort/AnalogReceivePort/EvenSendPort/etc...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ nineml_mechanisms
 *.project
 *.pydevproject
 *.settings
+*.pdf
+*.synctex.gz

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ nineml_mechanisms
 *.settings
 *.pdf
 *.synctex.gz
+/spec/*

--- a/lib9ml/python/developer_archive/test_old/test_to_resolve/test_AL_API.py
+++ b/lib9ml/python/developer_archive/test_old/test_to_resolve/test_AL_API.py
@@ -120,7 +120,7 @@ class ComponentTestCase(unittest.TestCase):
         ]
         r = nineml.Regime("dV/dt = 0.04*V*V + 5*V + 140.0 - U + Isyn + v1(v3(x))")
 
-        c1 = nineml.Component("Izhikevich", regimes=[r], aliases=aliases)
+        c1 = nineml.ComponentClass("Izhikevich", regimes=[r], aliases=aliases)
         c1.backsub_aliases()
         c1.backsub_equations()
 
@@ -178,7 +178,7 @@ class ComponentTestCase(unittest.TestCase):
         ports = [nineml.RecvPort("V"),
                  nineml.SendPort("Isyn = g(E-V)")]
 
-        coba_syn = nineml.Component("CoBaSynapse", regimes=regimes, ports=ports)
+        coba_syn = nineml.ComponentClass("CoBaSynapse", regimes=regimes, ports=ports)
 
         assert sorted(parameters) == sorted(coba_syn.parameters)
 
@@ -189,7 +189,7 @@ class ComponentTestCase(unittest.TestCase):
             transitions=[nineml.On(nineml.SpikeInputEvent, do="V+=10"),
                          nineml.On("V>Vth", do=["V=c", "U+=d", nineml.SpikeOutputEvent])])
 
-        c1 = nineml.Component("Izhikevich", regimes=[r], ports=[nineml.AnalogPort("V")])
+        c1 = nineml.ComponentClass("Izhikevich", regimes=[r], ports=[nineml.AnalogSendPort("V")])
         ap = list(c1.analog_ports)
 
         assert sorted([p.symbol for p in ap]) == sorted(['V', 'U', 't'])
@@ -201,7 +201,7 @@ class ComponentTestCase(unittest.TestCase):
             transitions=[nineml.On(nineml.SpikeInputEvent, do="V+=10"),
                          nineml.On("V>Vth", do=["V=c", "U+=d", nineml.SpikeOutputEvent])])
 
-        c1 = nineml.Component("Izhikevich", regimes=[r], ports=[nineml.AnalogPort("V")])
+        c1 = nineml.ComponentClass("Izhikevich", regimes=[r], ports=[nineml.AnalogSendPort("V")])
         ep = list(c1.event_ports)
         assert len(ep) == 2
 
@@ -217,7 +217,7 @@ class ComponentTestCase(unittest.TestCase):
         assert nineml.SpikeOutputEvent in ep
 
         # get just the "recv" EventPort
-        ep = list(c1.filter_ports(mode="recv", cls=nineml.EventPort))
+        ep = list(c1.filter_ports(mode="recv", cls=nineml.EventReceivePort))
         assert len(ep) == 1
         assert ep[0] == nineml.SpikeInputEvent
 
@@ -241,19 +241,19 @@ class ComponentTestCase(unittest.TestCase):
         # TODO: read from alias
         # c1 = nineml.Component("Izhikevich", regimes = [r], ports=[nineml.AnalogPort("_q10","send")] )
         # may not write to a alias
-        self.assertRaises(ValueError, nineml.Component, "Izhikevich",
+        self.assertRaises(ValueError, nineml.ComponentClass, "Izhikevich",
                           regimes=[r], ports=[nineml.AnalogReceivePort("_q10")])
 
         # may not read from an undefined symbol
-        self.assertRaises(ValueError, nineml.Component, "Izhikevich",
+        self.assertRaises(ValueError, nineml.ComponentClass, "Izhikevich",
                           regimes=[r], ports=[nineml.AnalogSendPort("_q11")])
 
         # Should be AnalogPort
-        self.assertRaises(ValueError, nineml.Component, "Izhikevich",
+        self.assertRaises(ValueError, nineml.ComponentClass, "Izhikevich",
                           regimes=[r], ports=[nineml.AnalogSendPort("_q10")])
 
         # Should be AnalogPort
-        self.assertRaises(ValueError, nineml.Component, "Izhikevich",
+        self.assertRaises(ValueError, nineml.ComponentClass, "Izhikevich",
                           regimes=[r], ports=[nineml.EventSendPort("_q10")])
 
         # EventPorts as nodes in Transitions
@@ -263,7 +263,7 @@ class ComponentTestCase(unittest.TestCase):
             "dV/dt = 0.04*V*V + 5*V + 140.0 - U + Isyn",
             transitions=nineml.On("V>Vth", do=[nineml.SpikeOutputEvent, myeventport]))
 
-        c1 = nineml.Component("Izhikevich", regimes=[r])
+        c1 = nineml.ComponentClass("Izhikevich", regimes=[r])
         ep = list(c1.event_ports)
         assert len(ep) == 2
 
@@ -271,7 +271,7 @@ class ComponentTestCase(unittest.TestCase):
         assert ep[1] == myeventport
 
         # ok
-        e = nineml.On("V>Vth", do=nineml.EventPort("hello", mode="send"))
+        e = nineml.On("V>Vth", do=nineml.EventSendPort("hello", mode="send"))
         # not ok: do=EventPort cannot recv
         self.assertRaises(
             ValueError, nineml.On, "V>Vth", do=nineml.EventReceivePort("hello", mode="recv"))
@@ -384,7 +384,7 @@ class ComponentTestCase(unittest.TestCase):
         # TODO: ok to read from a alias, where function aliases are most interesting.
         # p_q10 = nineml.AnalogPort("_q10(V)","send")
         # ports = [p_q10]
-        c1 = nineml.Component("Izhikevich", regimes=[r])
+        c1 = nineml.ComponentClass("Izhikevich", regimes=[r])
 
         # attribute lookup for ports and user parameters:
 

--- a/lib9ml/python/developer_archive/test_old/test_to_resolve/test_AL_API.py
+++ b/lib9ml/python/developer_archive/test_old/test_to_resolve/test_AL_API.py
@@ -223,14 +223,14 @@ class ComponentTestCase(unittest.TestCase):
 
         # check that Transition catches condition in mode="send"
         self.assertRaises(ValueError, nineml.On, nineml.SpikeOutputEvent, do="V+=10")
-        # check that it won't accept a simple port_factory
-        self.assertRaises(ValueError, nineml.On, nineml.port_factory("hello", mode="recv"), do="V+=10")
+        # check that it won't accept an analogport
+        self.assertRaises(ValueError, nineml.On, nineml.AnalogReceivePort("hello", dimension="voltage"), do="V+=10")
         # check that it won't accept an AnalogPort
         self.assertRaises(
-            ValueError, nineml.On, nineml.AnalogPort("hello", mode="recv"), do="V+=10")
+            ValueError, nineml.On, nineml.AnalogReceivePort("hello", dimension="voltage"), do="V+=10")
 
         # user defined EventPort should be ok.
-        e = nineml.On(nineml.EventPort("hello", mode="recv"), do="V+=10")
+        e = nineml.On(nineml.EventReceivePort("hello"), do="V+=10")
 
         r = nineml.Regime(
             "_q10(V):=exp(V)",
@@ -242,19 +242,19 @@ class ComponentTestCase(unittest.TestCase):
         # c1 = nineml.Component("Izhikevich", regimes = [r], ports=[nineml.AnalogPort("_q10","send")] )
         # may not write to a alias
         self.assertRaises(ValueError, nineml.Component, "Izhikevich",
-                          regimes=[r], ports=[nineml.AnalogPort("_q10", "recv")])
+                          regimes=[r], ports=[nineml.AnalogReceivePort("_q10")])
 
         # may not read from an undefined symbol
         self.assertRaises(ValueError, nineml.Component, "Izhikevich",
-                          regimes=[r], ports=[nineml.AnalogPort("_q11", "send")])
+                          regimes=[r], ports=[nineml.AnalogSendPort("_q11")])
 
         # Should be AnalogPort
         self.assertRaises(ValueError, nineml.Component, "Izhikevich",
-                          regimes=[r], ports=[nineml.port_factory("_q10", "send")])
+                          regimes=[r], ports=[nineml.AnalogSendPort("_q10")])
 
         # Should be AnalogPort
         self.assertRaises(ValueError, nineml.Component, "Izhikevich",
-                          regimes=[r], ports=[nineml.EventPort("_q10", "send")])
+                          regimes=[r], ports=[nineml.EventSendPort("_q10")])
 
         # EventPorts as nodes in Transitions
         # multiple EventPorts
@@ -274,7 +274,7 @@ class ComponentTestCase(unittest.TestCase):
         e = nineml.On("V>Vth", do=nineml.EventPort("hello", mode="send"))
         # not ok: do=EventPort cannot recv
         self.assertRaises(
-            ValueError, nineml.On, "V>Vth", do=nineml.EventPort("hello", mode="recv"))
+            ValueError, nineml.On, "V>Vth", do=nineml.EventReceivePort("hello", mode="recv"))
 
     def test_regime_basic(self):
 

--- a/lib9ml/python/developer_archive/test_old/test_to_resolve/test_AL_API.py
+++ b/lib9ml/python/developer_archive/test_old/test_to_resolve/test_AL_API.py
@@ -223,8 +223,8 @@ class ComponentTestCase(unittest.TestCase):
 
         # check that Transition catches condition in mode="send"
         self.assertRaises(ValueError, nineml.On, nineml.SpikeOutputEvent, do="V+=10")
-        # check that it won't accept a simple Port
-        self.assertRaises(ValueError, nineml.On, nineml.Port("hello", mode="recv"), do="V+=10")
+        # check that it won't accept a simple port_factory
+        self.assertRaises(ValueError, nineml.On, nineml.port_factory("hello", mode="recv"), do="V+=10")
         # check that it won't accept an AnalogPort
         self.assertRaises(
             ValueError, nineml.On, nineml.AnalogPort("hello", mode="recv"), do="V+=10")
@@ -250,7 +250,7 @@ class ComponentTestCase(unittest.TestCase):
 
         # Should be AnalogPort
         self.assertRaises(ValueError, nineml.Component, "Izhikevich",
-                          regimes=[r], ports=[nineml.Port("_q10", "send")])
+                          regimes=[r], ports=[nineml.port_factory("_q10", "send")])
 
         # Should be AnalogPort
         self.assertRaises(ValueError, nineml.Component, "Izhikevich",

--- a/lib9ml/python/developer_archive/test_old/test_to_resolve/test_roundtripUL.py
+++ b/lib9ml/python/developer_archive/test_old/test_to_resolve/test_roundtripUL.py
@@ -25,7 +25,7 @@ def simple_example():
         {'lowerBound': (-70.0, "dimensionless"),
          'upperBound': (-60.0, "dimensionless")})
 
-    exc_cell_parameters = nineml.ParameterSet(
+    exc_cell_properties = nineml.PropertySet(
         membraneCapacitance=(1.0, "nF"),
         membraneTimeConstant=(tau_distr, "ms"),
         refractoryTime=(5.0, "ms"),
@@ -33,18 +33,18 @@ def simple_example():
         restingPotential=(-65.0, "mV"),
         resetPotential=(reset_distr, "mV"))
 
-    inh_cell_parameters = nineml.ParameterSet(
+    inh_cell_properties = nineml.PropertySet(
         membraneTimeConstant=(20.0, "ms"),
         resetPotential=(-60.0, "mV"))
 
-    inh_cell_parameters.complete(exc_cell_parameters)
+    inh_cell_properties.complete(exc_cell_properties)
 
     exc_celltype = nineml.SpikingNodeType("Excitatory neuron type",
                                           catalog + "neurons/IaF_tau.xml",
-                                          exc_cell_parameters)
+                                          exc_cell_properties)
     inh_celltype = nineml.SpikingNodeType("Inhibitory neuron type",
                                           catalog + "neurons/IaF_tau.xml",
-                                          inh_cell_parameters)
+                                          inh_cell_properties)
 
     grid2D = nineml.Structure("2D grid",
                               catalog + "networkstructures/2Dgrid.xml",
@@ -112,7 +112,7 @@ simple_example = simple_example()
 def nested_example():
     catalog = "http://svn.incf.org/svn/nineml/catalog/"
 
-    cell_parameters = {
+    cell_properties = {
         "membraneCapacitance": (1.0, "nF"),
         "membraneTimeConstant": (20.0, "ms"),
         "refractoryTime": (5.0, "ms"),
@@ -124,17 +124,17 @@ def nested_example():
     exc_celltype = nineml.SpikingNodeType(
         name="Excitatory neuron type",
         definition=catalog + "neurons/IaF_tau.xml",
-        parameters=cell_parameters)
+        properties=cell_properties)
 
     inh_celltype = nineml.SpikingNodeType(
         name="Inhibitory neuron type",
         definition=catalog + "neurons/IaF_tau.xml",
-        parameters=cell_parameters)
+        properties=cell_properties)
 
     inner_grid = nineml.Structure(
         name="neuronal grid with 1 micron spacing",
         definition=catalog + "networkstructures/2Dgrid.xml",
-        parameters={'fillOrder': ("sequential", None),
+        properties={'fillOrder': ("sequential", None),
                     'aspectRatioXY': (1.0, "dimensionless"),
                     'dx': (1.0, u"µm"), 'dy': (1.0, u"µm"),
                     'x0': (0.0, u"µm"), 'y0': (0.0, u"µm")})
@@ -142,7 +142,7 @@ def nested_example():
     outer_grid = nineml.Structure(
         name="column grid with 100 micron spacing",
         reference=inner_grid.name,
-        parameters={'dx': (100.0, u"µm"), 'dy': (100.0, u"µm")})
+        properties={'dx': (100.0, u"µm"), 'dy': (100.0, u"µm")})
 
     exc_cells = nineml.Population(
         name="Excitatory cells",
@@ -162,27 +162,27 @@ def nested_example():
     exc_psr = nineml.SynapseType(
         name="Excitatory post-synaptic response",
         definition=catalog + "postsynapticresponses/exp_g.xml",
-        parameters={'decayTimeConstant': (5.0, "ms"),
+        properties={'decayTimeConstant': (5.0, "ms"),
                     'reversalPotential': (0.0, "mV")})
     inh_psr = nineml.SynapseType(
         name="Inhibitory post-synaptic response",
         reference=exc_psr.name,
-        parameters={'reversalPotential': (-70.0, "mV")})
+        properties={'reversalPotential': (-70.0, "mV")})
 
     exc_connection_type = nineml.ConnectionType(
         name="Static excitatory connections",
         definition=catalog + "connectiontypes/static_connection.xml",
-        parameters={'weight': (0.1, "nS"), 'delay': (0.3, "ms")})
+        properties={'weight': (0.1, "nS"), 'delay': (0.3, "ms")})
 
     inh_connection_type = nineml.ConnectionType(
         name="Static inhibitory connections",
         reference=exc_connection_type.name,
-        parameters={'weight': (0.2, "nS")})
+        properties={'weight': (0.2, "nS")})
 
     intra_column_connector = nineml.ConnectionRule(
         name="local random connections",
         definition=catalog + "connectionrules/fixed_probability.xml",
-        parameters={'p_connect': (0.1, "dimensionless")})
+        properties={'p_connect': (0.1, "dimensionless")})
 
     inner_exc2all = nineml.Projection(
         name="Intra-column excitatory connections",
@@ -205,7 +205,7 @@ def nested_example():
     inter_column_connector = nineml.ConnectionRule(
         name="lateral random connections",
         reference=intra_column_connector.name,
-        parameters={'p_connect': (0.05, "dimensionless")})
+        properties={'p_connect': (0.05, "dimensionless")})
 
     network = nineml.Group("Network")
 

--- a/lib9ml/python/nineml/abstraction_layer/__init__.py
+++ b/lib9ml/python/nineml/abstraction_layer/__init__.py
@@ -12,7 +12,9 @@ from nineml import __version__
 from components import Parameter, BaseComponentClass
 from dynamics.component import (ComponentClass, Regime, On, OutputEvent,
                                 StateAssignment, TimeDerivative, ReducePort,
-                                AnalogPort, EventPort, Dynamics, OnCondition,
+                                AnalogSendPort, AnalogReceivePort,
+                                AnalogReducePort, EventSendPort,
+                                EventReceivePort, Dynamics, OnCondition,
                                 Condition, StateVariable, NamespaceAddress,
                                 RecvPort, SendPort, Alias, OnEvent,
                                 SpikeOutputEvent, SendEventPort, RecvEventPort,

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/__init__.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/__init__.py
@@ -7,7 +7,8 @@ Python module for reading 9ML abstraction layer files in XML format.
 
 from .component import (ComponentClass, Regime, On, OutputEvent,
                         StateAssignment, TimeDerivative, ReducePort,
-                        AnalogPort, EventPort, Dynamics, OnCondition,
+                        AnalogSendPort, AnalogReceivePort, AnalogReducePort,
+                        EventSendPort, EventReceivePort, Dynamics, OnCondition,
                         Condition, StateVariable, NamespaceAddress, RecvPort,
                         SendPort, Alias, OnEvent, SpikeOutputEvent,
                         SendEventPort, RecvEventPort, Expression)

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/component/__init__.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/component/__init__.py
@@ -12,7 +12,8 @@ from expressions import RegimeElement,  Expression, Equation
 from expressions import ExpressionWithLHS, ExpressionWithSimpleLHS, Alias
 from expressions import StateAssignment, TimeDerivative, StrToExpr
 from conditions import Condition
-from ports import Port, AnalogPort, EventPort
+from ports import (AnalogSendPort, AnalogReceivePort, AnalogReducePort,
+                   EventSendPort, EventReceivePort)
 from ports import ReducePort, RecvPort, SendPort, RecvEventPort, SendEventPort
 
 from events import OutputEvent

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/component/ports.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/component/ports.py
@@ -164,7 +164,7 @@ class AnalogReducePort(AnalogPort):
     _reduce_op_map = {'add': '+', '+': '+', }
 
     def __init__(self, name, dimension, reduce_op='+'):
-        if reduce_op not in Port._reduce_op_map.keys():
+        if reduce_op not in self._reduce_op_map.keys():
             err = ("%s('%s')" + "specified undefined reduce_op: '%s'") %\
                   (self.__class__.__name__, name, str(reduce_op))
             raise NineMLRuntimeError(err)
@@ -174,6 +174,10 @@ class AnalogReducePort(AnalogPort):
     def accept_visitor(self, visitor, **kwargs):
         """ |VISITATION| """
         return visitor.visit_analogreduceport(self, **kwargs)
+
+    @property
+    def reduce_op(self):
+        return self._reduce_op
 
     def __repr__(self):
         classstring = self.__class__.__name__

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/component/ports.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/component/ports.py
@@ -1,5 +1,5 @@
 """
-This file defines the port_factory classes used in NineML
+This file defines the Port classes used in NineML
 
 :copyright: Copyright 2010-2013 by the Python lib9ML team, see AUTHORS.
 :license: BSD-3, see LICENSE for details.
@@ -40,7 +40,7 @@ class Port(object):
     __metaclass__ = ABCMeta  # Ensure abstract base class isn't instantiated
 
     def __init__(self, name):
-        """ port_factory Constructor.
+        """ Port Constructor.
 
         :param name: The name of the port, as a `string`
         """
@@ -64,7 +64,7 @@ class AnalogPort(Port):
     """
     __metaclass__ = ABCMeta  # Ensure abstract base class isn't instantiated
 
-    def __init__(self, name, dimension):
+    def __init__(self, name, dimension=None):
         super(AnalogPort, self).__init__(name)
         self._dimension = dimension  # TODO: This needs checking
 
@@ -179,35 +179,6 @@ class AnalogReducePort(AnalogPort):
         classstring = self.__class__.__name__
         return ("{}('{}', dimension='{}', op='{}')"
                .format(classstring, self.name, self.dimension, self.reduce_op))
-
-
-def port_factory(name, mode='send', reduce_op=None,
-                 dimension='dimensionless'):
-    """ port_factory Constructor.
-
-    :param name: The name of the port, as a `string`
-    :param mode: The mode of the port, which should be a string as either,
-        ``send``,``recv`` or ``reduce``.
-    :param reduce_op: This should be ``None`` unless the mode is
-        ``reduce``. If the mode is ``reduce``, then this must be a
-        supported ``reduce_op``
-
-    .. note::
-
-        Currently support ``reduce_op`` s are: ``+``.
-
-    """
-    if mode == 'reduce':
-        return AnalogReducePort(name=name, dimension=dimension,
-                                reduce_op=reduce_op)
-    elif mode == 'send':
-        return AnalogSendPort(name, dimension)
-    elif mode in ('receive', 'recv'):
-        return AnalogReceivePort(name, dimension)
-    else:
-        err = ("%s('%s')" + "specified undefined mode: '%s'") %\
-              ('port_factory', 'none', mode)
-        raise NineMLRuntimeError(err)
 
 
 # Syntactic sugar

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/readers/xml_reader.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/readers/xml_reader.py
@@ -51,36 +51,50 @@ class XMLLoader(object):
 
     def load_componentclass(self, element):
 
-        blocks = ('Parameter', 'AnalogPort', 'EventPort',
+        blocks = ('Parameter', 'AnalogSendPort', 'AnalogReceivePort',
+                  'EventSendPort', 'EventReceivePort', 'AnalogReducePort',
                   'Dynamics', 'Subnode', 'ConnectPorts', 'Component')
 
         subnodes = self.loadBlocks(element, blocks=blocks)
 
         dynamics = expect_single(subnodes["Dynamics"])
-        return al.ComponentClass(name=element.get('name'),
-                                 parameters=subnodes["Parameter"],
-                                 analog_ports=subnodes["AnalogPort"],
-                                 event_ports=subnodes["EventPort"],
-                                 dynamics=dynamics,
-                                 subnodes=dict(subnodes['Subnode']),
-                                 portconnections=subnodes["ConnectPorts"])
+        return al.ComponentClass(
+                         name=element.get('name'),
+                         parameters=subnodes["Parameter"],
+                         analog_send_ports=subnodes["AnalogSendPort"],
+                         analog_receive_ports=subnodes["AnalogReceivePort"],
+                         analog_reduce_ports=subnodes["AnalogReducePort"],
+                         event_send_ports=subnodes["EventSendPort"],
+                         event_receive_ports=subnodes["EventReceivePort"],
+                         dynamics=dynamics,
+                         subnodes=dict(subnodes['Subnode']),
+                         portconnections=subnodes["ConnectPorts"])
 
-    def load_subcomponent(self, element):
-        return al.SubComponent(name=element.get('name'))
+#     def load_subcomponent(self, element):
+#         return al.SubComponent(name=element.get('name'))
 
     def load_parameter(self, element):
         return Parameter(name=element.get('name'),
                          dimension=element.get('dimension'))
 
-    def load_analogport(self, element):
-        return al.AnalogPort(name=element.get("name"),
-                                    mode=element.get('mode'),
-                                    reduce_op=element.get("reduce_op", None)
-                                    )
+    def load_eventsendport(self, element):
+        return al.EventSendPort(name=element.get('name'))
 
-    def load_eventport(self, element):
-        return al.EventPort(name=element.get('name'),
-                                   mode=element.get('mode'))
+    def load_eventreceiveport(self, element):
+        return al.EventReceivePort(name=element.get('name'))
+
+    def load_analogsendport(self, element):
+        return al.AnalogSendPort(name=element.get("name"),
+                                 dimension=element.get('dimension'))
+
+    def load_analogreceiveport(self, element):
+        return al.AnalogReceivePort(name=element.get("name"),
+                                    dimension=element.get('dimension'))
+
+    def load_analogreduceport(self, element):
+        return al.EventReducePort(name=element.get('name'),
+                                  dimension=element.get('dimension'),
+                                  reduce_op=element.get("reduce_op"))
 
     def load_dynamics(self, element):
         subblocks = ('Regime', 'Alias', 'StateVariable')
@@ -202,12 +216,15 @@ class XMLLoader(object):
 
     tag_to_loader = {
         "ComponentClass": load_componentclass,
-        "Component": load_subcomponent,
+#         "Component": load_subcomponent,
         "Regime": load_regime,
         "StateVariable": load_statevariable,
         "Parameter": load_parameter,
-        "EventPort": load_eventport,
-        "AnalogPort": load_analogport,
+        "EventSendPort": load_eventsendport,
+        "AnalogSendPort": load_analogsendport,
+        "EventReceivePort": load_eventreceiveport,
+        "AnalogReceivePort": load_analogreceiveport,
+        "AnalogReducePort": load_analogreduceport,
         "Dynamics": load_dynamics,
         "OnCondition": load_oncondition,
         "OnEvent": load_onevent,

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/readers/xml_reader.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/readers/xml_reader.py
@@ -92,7 +92,7 @@ class XMLLoader(object):
                                     dimension=element.get('dimension'))
 
     def load_analogreduceport(self, element):
-        return al.EventReducePort(name=element.get('name'),
+        return al.AnalogReducePort(name=element.get('name'),
                                   dimension=element.get('dimension'),
                                   reduce_op=element.get("reduce_op"))
 
@@ -145,11 +145,10 @@ class XMLLoader(object):
         subnodes = self.loadBlocks(element, blocks=subblocks)
         target_regime_name = element.get('target_regime', None)
 
-        return al.OnEvent(src_port_name=element.get('src_port'),
-                                 state_assignments=subnodes["StateAssignment"],
-                                 event_outputs=subnodes["EventOut"],
-                                 target_regime_name=target_regime_name
-                                 )
+        return al.OnEvent(src_port_name=element.get('port'),
+                          state_assignments=subnodes["StateAssignment"],
+                          event_outputs=subnodes["EventOut"],
+                          target_regime_name=target_regime_name)
 
     def load_trigger(self, element):
         return self.load_single_internal_maths_block(element)

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_general.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_general.py
@@ -64,8 +64,7 @@ class ComponentValidatorStateAssignmentsAreOnStateVariables(
                                                                    iteritems():
             for td in state_assignments_lhs:
                 if not td in self.sv_declared[namespace]:
-                    err = ('Not Assigning to state-variable: %s' %
-                           state_assignment)
+                    err = 'Not Assigning to state-variable: {}'.format(td)
                     raise NineMLRuntimeError(err)
 
     def action_statevariable(self, state_variable, namespace, **kwargs):  # @UnusedVariable @IgnorePep8

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_general.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_general.py
@@ -170,9 +170,8 @@ class ComponentValidatorAssignmentsAliasesAndStateVariablesHaveNoUnResolvedSymbo
             raise NineMLRuntimeError(err)
         self.available_symbols[namespace].append(symbol)
 
-    def action_analogport(self, port, namespace, **kwargs):  # @UnusedVariable
-        if port.is_incoming():
-            self.available_symbols[namespace].append(port.name)
+    def action_analogreceiveport(self, port, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
+        self.available_symbols[namespace].append(port.name)
 
     def action_statevariable(self, state_variable, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
         self.add_symbol(namespace=namespace, symbol=state_variable.name)
@@ -246,19 +245,27 @@ class ComponentValidatorPortConnections(ComponentValidatorPerNamespace):
                         "Port was 'recv' and specified twice: %s" % (sink))
                 connected_recv_ports.add(self.ports[sink])
 
-    def action_analogport(self, analogport, namespace):
-        port_address = NamespaceAddress.concat(namespace, analogport.name)
+    def _action_port(self, port, namespace):
+        port_address = NamespaceAddress.concat(namespace, port.name)
         if port_address in self.ports:
             raise NineMLRuntimeError(
                 'Duplicated Name for port found: %s' % port_address)
-        self.ports[port_address] = analogport
+        self.ports[port_address] = port
 
-    def action_eventport(self, analogport, namespace):
-        port_address = NamespaceAddress.concat(namespace, analogport.name)
-        if port_address in self.ports:
-            raise NineMLRuntimeError(
-                'Duplicated Name for port found: %s' % port_address)
-        self.ports[port_address] = analogport
+    def action_analogsendport(self, analogsendport, namespace):
+        self._action_port(analogsendport, namespace)
+
+    def action_analogreceiveport(self, analogreceiveport, namespace):
+        self._action_port(analogreceiveport, namespace)
+
+    def action_analogreduceport(self, analogreduceport, namespace):
+        self._action_port(analogreduceport, namespace)
+
+    def action_eventsendport(self, eventsendport, namespace):
+        self._action_port(eventsendport, namespace)
+
+    def action_eventreceiveport(self, eventreceiveport, namespace):
+        self._action_port(eventreceiveport, namespace)
 
     def action_componentclass(self, component, namespace):
         for src, sink in component.portconnections:
@@ -334,10 +341,19 @@ class ComponentValidatorNoDuplicatedObjects(ComponentValidatorPerNamespace):
     def action_parameter(self, parameter, **kwargs):  # @UnusedVariable
         self.all_objects.append(parameter)
 
-    def action_analogport(self, port, **kwargs):  # @UnusedVariable
+    def action_analogsendport(self, port, **kwargs):  # @UnusedVariable
         self.all_objects.append(port)
 
-    def action_eventport(self, port, **kwargs):  # @UnusedVariable
+    def action_analogreceiveport(self, port, **kwargs):  # @UnusedVariable
+        self.all_objects.append(port)
+
+    def action_analogreduceport(self, port, **kwargs):  # @UnusedVariable
+        self.all_objects.append(port)
+
+    def action_eventsendport(self, port, **kwargs):  # @UnusedVariable
+        self.all_objects.append(port)
+
+    def action_eventreceiveport(self, port, **kwargs):  # @UnusedVariable
         self.all_objects.append(port)
 
     def action_outputevent(self, output_event, **kwargs):  # @UnusedVariable

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_general.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_general.py
@@ -173,6 +173,9 @@ class ComponentValidatorAssignmentsAliasesAndStateVariablesHaveNoUnResolvedSymbo
     def action_analogreceiveport(self, port, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
         self.available_symbols[namespace].append(port.name)
 
+    def action_analogreduceport(self, port, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
+        self.available_symbols[namespace].append(port.name)
+
     def action_statevariable(self, state_variable, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
         self.add_symbol(namespace=namespace, symbol=state_variable.name)
 

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_namingconflicts.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_namingconflicts.py
@@ -29,27 +29,28 @@ class ComponentValidatorLocalNameConflicts(ComponentValidatorPerNamespace):
 
         self.visit(component)
 
-    def check_comflicting_symbol(self, namespace, symbol):
+    def check_conflicting_symbol(self, namespace, symbol):
         if symbol in self.symbols[namespace]:
             err = 'Duplication of symbol found: %s in %s' % (symbol, namespace)
             raise NineMLRuntimeError(err)
         self.symbols[namespace].append(symbol)
 
     def action_statevariable(self, state_variable, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
-        self.check_comflicting_symbol(namespace=namespace,
+        self.check_conflicting_symbol(namespace=namespace,
                                       symbol=state_variable.name)
 
     def action_parameter(self, parameter, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
-        self.check_comflicting_symbol(namespace=namespace,
+        self.check_conflicting_symbol(namespace=namespace,
                                       symbol=parameter.name)
 
-    def action_analogport(self, port, namespace, **kwargs):  # @UnusedVariable
-        if port.is_incoming():
-            self.check_comflicting_symbol(namespace=namespace,
-                                          symbol=port.name)
+    def action_analogreceiveport(self, port, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
+        self.check_conflicting_symbol(namespace=namespace, symbol=port.name)
 
-    def action_eventport(self, port, namespace, **kwargs):  # @UnusedVariable
-        self.check_comflicting_symbol(namespace=namespace, symbol=port.name)
+    def action_analogreduceport(self, port, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
+        self.check_conflicting_symbol(namespace=namespace, symbol=port.name)
+
+    def action_eventreceiveport(self, port, namespace, **kwargs):  # @UnusedVariable
+        self.check_conflicting_symbol(namespace=namespace, symbol=port.name)
 
     def action_alias(self, alias, namespace, **kwargs):  # @UnusedVariable
-        self.check_comflicting_symbol(namespace=namespace, symbol=alias.lhs)
+        self.check_conflicting_symbol(namespace=namespace, symbol=alias.lhs)

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_ports.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_ports.py
@@ -4,7 +4,7 @@ docstring needed
 :copyright: Copyright 2010-2013 by the Python lib9ML team, see AUTHORS.
 :license: BSD-3, see LICENSE for details.
 """
-
+from itertools import chain
 from nineml.exceptions import NineMLRuntimeError
 from collections import defaultdict
 from nineml.abstraction_layer.dynamics.validators.base import ComponentValidatorPerNamespace  # @IgnorePep8
@@ -22,7 +22,8 @@ class ComponentValidatorEventPorts(ComponentValidatorPerNamespace):
                                      explicitly_require_action_overrides=False)
 
         # Mapping component to list of events/eventports at that component
-        self.events_ports = defaultdict(dict)
+        self.event_send_ports = defaultdict(dict)
+        self.event_receive_ports = defaultdict(dict)
         self.output_events = defaultdict(list)
         self.input_events = defaultdict(list)
 
@@ -32,22 +33,19 @@ class ComponentValidatorEventPorts(ComponentValidatorPerNamespace):
         # send mode:
         for ns, output_events in self.output_events.iteritems():
             for output_event in output_events:
-
-                assert output_event in self.events_ports[ns], \
+                assert output_event in self.event_send_ports[ns], \
                           ("Can't find port definition matching OP-Event: %s" %
                            output_event)
-                assert self.events_ports[ns][output_event].mode == 'send'
 
         # Check that each input event has a corresponding event_port with a
         # recv/reduce mode:
         for ns, input_events in self.input_events.iteritems():
             for input_event in input_events:
-                assert input_event in self.events_ports[ns]
-                assert self.events_ports[ns][input_event].mode in ('recv',
-                                                                   'reduce')
+                assert input_event in self.event_receive_ports[ns]
 
         # Check that each Event port emits/recieves at least one
-        for ns, event_ports in self.events_ports.iteritems():
+        for ns, event_ports in chain(self.event_send_ports.iteritems(),
+                                     self.event_receive_ports.iteritems()):
             for evt_port_name in event_ports.keys():
 
                 op_evts_on_port = [ev for ev in self.output_events[ns]
@@ -60,12 +58,12 @@ class ComponentValidatorEventPorts(ComponentValidatorPerNamespace):
                            evt_port_name)
 
     def action_eventsendport(self, port, namespace, **kwargs):  # @UnusedVariable
-        assert not port.name in self.events_ports[namespace]
-        self.events_ports[namespace][port.name] = port
+        assert not port.name in self.event_send_ports[namespace]
+        self.event_send_ports[namespace][port.name] = port
 
     def action_eventreceiveport(self, port, namespace, **kwargs):  # @UnusedVariable
-        assert not port.name in self.events_ports[namespace]
-        self.events_ports[namespace][port.name] = port
+        assert not port.name in self.event_receive_ports[namespace]
+        self.event_receive_ports[namespace][port.name] = port
 
     def action_outputevent(self, output_event, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
         self.output_events[namespace].append(output_event.port_name)

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_ports.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_ports.py
@@ -59,7 +59,11 @@ class ComponentValidatorEventPorts(ComponentValidatorPerNamespace):
                     print ('Unable to find events generated for: ', ns,
                            evt_port_name)
 
-    def action_eventport(self, port, namespace, **kwargs):  # @UnusedVariable
+    def action_eventsendport(self, port, namespace, **kwargs):  # @UnusedVariable
+        assert not port.name in self.events_ports[namespace]
+        self.events_ports[namespace][port.name] = port
+
+    def action_eventreceiveport(self, port, namespace, **kwargs):  # @UnusedVariable
         assert not port.name in self.events_ports[namespace]
         self.events_ports[namespace][port.name] = port
 
@@ -99,9 +103,8 @@ class ComponentValidatorOutputAnalogPorts(ComponentValidatorPerNamespace):
         assert not symbol in self.available_symbols[namespace]
         self.available_symbols[namespace].append(symbol)
 
-    def action_analogport(self, port, namespace, **kwargs):  # @UnusedVariable
-        if not port.is_incoming():
-            self.output_analogports[namespace].append(port.name)
+    def action_analogsendport(self, port, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
+        self.output_analogports[namespace].append(port.name)
 
     def action_statevariable(self, state_variable, namespace, **kwargs):  # @UnusedVariable @IgnorePep8
         self.add_symbol(namespace=namespace, symbol=state_variable.name)

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_types.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/validators/cv_types.py
@@ -31,11 +31,20 @@ class ComponentValidatorTypes(ActionVisitor):
         assert isinstance(parameter, Parameter), \
                                       "%s != %s" % (type(parameter), Parameter)
 
-    def action_analogport(self, port, **kwargs):  # @UnusedVariable
-        assert isinstance(port, al.AnalogPort)
+    def action_analogsendport(self, port, **kwargs):  # @UnusedVariable
+        assert isinstance(port, al.AnalogSendPort)
 
-    def action_eventport(self, port, **kwargs):  # @UnusedVariable
-        assert isinstance(port, al.EventPort)
+    def action_analogreceiveport(self, port, **kwargs):  # @UnusedVariable
+        assert isinstance(port, al.AnalogReceivePort)
+
+    def action_analogreduceport(self, port, **kwargs):  # @UnusedVariable
+        assert isinstance(port, al.AnalogReducePort)
+
+    def action_eventsendport(self, port, **kwargs):  # @UnusedVariable
+        assert isinstance(port, al.EventSendPort)
+
+    def action_eventreceiveport(self, port, **kwargs):  # @UnusedVariable
+        assert isinstance(port, al.EventReceivePort)
 
     def action_outputevent(self, output_event, **kwargs):  # @UnusedVariable
         assert isinstance(output_event, al.OutputEvent)

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/visitors/base.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/visitors/base.py
@@ -23,8 +23,7 @@ class ActionVisitor(ComponentVisitor):
     def visit_componentclass(self, component, **kwargs):
         self.action_componentclass(component, **kwargs)
 
-        nodes = chain(component.parameters, component.analog_ports,
-                      component.event_ports)
+        nodes = chain(component.parameters, component.ports)
         for p in nodes:
             p.accept_visitor(self, **kwargs)
 
@@ -54,11 +53,20 @@ class ActionVisitor(ComponentVisitor):
     def visit_parameter(self, parameter, **kwargs):
         self.action_parameter(parameter, **kwargs)
 
-    def visit_analogport(self, port, **kwargs):
-        self.action_analogport(port, **kwargs)
+    def visit_analogsendport(self, port, **kwargs):
+        self.action_analogsendport(port, **kwargs)
 
-    def visit_eventport(self, port, **kwargs):
-        self.action_eventport(port, **kwargs)
+    def visit_analogreceiveport(self, port, **kwargs):
+        self.action_analogreceiveport(port, **kwargs)
+
+    def visit_analogreduceport(self, port, **kwargs):
+        self.action_analogreduceport(port, **kwargs)
+
+    def visit_eventsendport(self, port, **kwargs):
+        self.action_eventsendport(port, **kwargs)
+
+    def visit_eventreceiveport(self, port, **kwargs):
+        self.action_eventreceiveport(port, **kwargs)
 
     def visit_outputevent(self, output_event, **kwargs):
         self.action_outputevent(output_event, **kwargs)
@@ -117,10 +125,19 @@ class ActionVisitor(ComponentVisitor):
     def action_parameter(self, parameter, **kwargs):  # @UnusedVariable
         self.check_pass()
 
-    def action_analogport(self, port, **kwargs):  # @UnusedVariable
+    def action_analogsendport(self, port, **kwargs):  # @UnusedVariable
         self.check_pass()
 
-    def action_eventport(self, port, **kwargs):  # @UnusedVariable
+    def action_analogreceiveport(self, port, **kwargs):  # @UnusedVariable
+        self.check_pass()
+
+    def action_analogreduceport(self, port, **kwargs):  # @UnusedVariable
+        self.check_pass()
+
+    def action_eventsendport(self, port, **kwargs):  # @UnusedVariable
+        self.check_pass()
+
+    def action_eventreceiveport(self, port, **kwargs):  # @UnusedVariable
         self.check_pass()
 
     def action_outputevent(self, output_event, **kwargs):  # @UnusedVariable

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/visitors/cloner.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/visitors/cloner.py
@@ -171,7 +171,7 @@ class RenameSymbol(ActionVisitor):
 
     def action_onevent(self, on_event, **kwargs):  # @UnusedVariable
         if on_event.src_port_name == self.old_symbol_name:
-            on_event._src_port_name = self.new_symbol_name
+            on_event._port_name = self.new_symbol_name
             self.note_rhs_changed(on_event)
 
 

--- a/lib9ml/python/nineml/abstraction_layer/dynamics/visitors/cloner.py
+++ b/lib9ml/python/nineml/abstraction_layer/dynamics/visitors/cloner.py
@@ -114,15 +114,25 @@ class RenameSymbol(ActionVisitor):
             parameter._name = self.new_symbol_name
             self.note_lhs_changed(parameter)
 
-    def action_analogport(self, port, **kwargs):  # @UnusedVariable
+    def _action_port(self, port, **kwargs):  # @UnusedVariable
         if port.name == self.old_symbol_name:
             port._name = self.new_symbol_name
             self.note_port_changed(port)
 
-    def action_eventport(self, port, **kwargs):  # @UnusedVariable
-        if port.name == self.old_symbol_name:
-            port._name = self.new_symbol_name
-            self.note_port_changed(port)
+    def action_analogsendport(self, port, **kwargs):  # @UnusedVariable
+        self._action_port(port, **kwargs)
+
+    def action_analogreceiveport(self, port, **kwargs):  # @UnusedVariable
+        self._action_port(port, **kwargs)
+
+    def action_analogreduceport(self, port, **kwargs):  # @UnusedVariable
+        self._action_port(port, **kwargs)
+
+    def action_eventsendport(self, port, **kwargs):  # @UnusedVariable
+        self._action_port(port, **kwargs)
+
+    def action_eventreceiveport(self, port, **kwargs):  # @UnusedVariable
+        self._action_port(port, **kwargs)
 
     def action_outputevent(self, output_event, **kwargs):  # @UnusedVariable
         if output_event.port_name == self.old_symbol_name:

--- a/lib9ml/python/nineml/abstraction_layer/xmlns.py
+++ b/lib9ml/python/nineml/abstraction_layer/xmlns.py
@@ -6,5 +6,5 @@ docstring goes here
 """
 
 MATHML = "{http://www.w3.org/1998/Math/MathML}"
-nineml_namespace = 'http://nineml.incf.org/9ML/0.3'
+nineml_namespace = 'http://nineml.net/9ML/1.0'
 NINEML = "{%s}" % nineml_namespace

--- a/lib9ml/python/nineml/user_layer/__init__.py
+++ b/lib9ml/python/nineml/user_layer/__init__.py
@@ -20,7 +20,7 @@ Classes
         ConnectionType
         RandomDistribution
     Parameter
-    ParameterSet
+    PropertySet
     Value
     Group
     Population
@@ -51,7 +51,7 @@ from .population import (Population, PositionList, Structure, Selection,
 from .containers import Model, Group
 from .projection import Projection, ConnectionRule, ConnectionType
 from .random import RandomDistribution
-from .components import ParameterSet
+from .components import PropertySet
 
 
 def parse(url):

--- a/lib9ml/python/nineml/user_layer/base.py
+++ b/lib9ml/python/nineml/user_layer/base.py
@@ -2,7 +2,7 @@ from itertools import chain
 from operator import and_
 from lxml.builder import ElementMaker
 
-nineml_namespace = 'http://nineml.incf.org/9ML/0.3'
+nineml_namespace = 'http://nineml.net/9ML/1.0'
 NINEML = "{%s}" % nineml_namespace
 
 E = ElementMaker(namespace=nineml_namespace,

--- a/lib9ml/python/nineml/user_layer/components/__init__.py
+++ b/lib9ml/python/nineml/user_layer/components/__init__.py
@@ -1,2 +1,2 @@
 from .base import BaseComponent, get_or_create_component
-from .interface import Value, StringValue, Property, InitialValue, PropertySet
+from .interface import Quantity, StringValue, Property, InitialValue, PropertySet

--- a/lib9ml/python/nineml/user_layer/components/__init__.py
+++ b/lib9ml/python/nineml/user_layer/components/__init__.py
@@ -1,2 +1,2 @@
 from .base import BaseComponent, get_or_create_component
-from .interface import Value, StringValue, Parameter, InitialValue, ParameterSet
+from .interface import Value, StringValue, Property, InitialValue, PropertySet

--- a/lib9ml/python/nineml/user_layer/components/base.py
+++ b/lib9ml/python/nineml/user_layer/components/base.py
@@ -16,7 +16,7 @@ class Definition(BaseULObject):
     For now, this holds only the URI of an abstraction layer file, but this
     could be expanded later to include definitions external to 9ML.
     """
-    element_name = "definition"
+    element_name = "Definition"
     defining_attributes = ("url",)
 
     def __init__(self, component, abstraction_layer_module=None):
@@ -89,7 +89,7 @@ class BaseComponent(BaseULObject):
     """
     Base class for model components that are defined in the abstraction layer.
     """
-    element_name = "component"
+    element_name = "Component"
     defining_attributes = ("name", "definition", "parameters")
     children = ("parameters",)
 

--- a/lib9ml/python/nineml/user_layer/components/interface.py
+++ b/lib9ml/python/nineml/user_layer/components/interface.py
@@ -69,7 +69,7 @@ class Property(BaseULObject):
     def from_xml(cls, element, components):
         check_tag(element, cls)
         quantity_element = element.find(NINEML +
-                                        "quantity").find(NINEML + "value")
+                                        "Quantity").find(NINEML + "Value")
         value, unit = Value.from_xml(quantity_element, components)
         return Property(name=element.attrib["name"],
                          value=value,

--- a/lib9ml/python/nineml/user_layer/components/interface.py
+++ b/lib9ml/python/nineml/user_layer/components/interface.py
@@ -19,7 +19,7 @@ class Parameter(BaseULObject):
     Numerical values may either be numbers, or a component that generates
     numbers, e.g. a RandomDistribution instance.
     """
-    element_name = "property"
+    element_name = "Property"
     defining_attributes = ("name", "value", "unit")
 
     def __init__(self, name, value, unit=None):
@@ -81,7 +81,7 @@ class Value(object):
     """
     Not intended to be instantiated: just provides the from_xml() classmethod.
     """
-    element_name = "value"
+    element_name = "Value"
 
     @classmethod
     def from_xml(cls, element, components):
@@ -120,7 +120,7 @@ class StringValue(object):
     """
     Not intended to be instantiated: just provides the from_xml() classmethod.
     """
-    element_name = "value"
+    element_name = "Value"
 
     @classmethod
     def from_xml(cls, element):
@@ -137,7 +137,7 @@ class InitialValue(BaseULObject):
     """
     temporary, longer-term plan is to use SEDML or something similar
     """
-    element_name = "initial"
+    element_name = "Initial"
     defining_attributes = ("name", "value", "unit")
 
     def __init__(self, name, value, unit=None):

--- a/lib9ml/python/nineml/user_layer/components/interface.py
+++ b/lib9ml/python/nineml/user_layer/components/interface.py
@@ -60,9 +60,9 @@ class Parameter(BaseULObject):
             value_element = E.scalar(repr(self.value))
         return E(Parameter.element_name,
                  E.quantity(
-                 E.value(   # this extra level of tags is pointless, no?
+#                  E.value(   # this extra level of tags is pointless, no?
                  value_element,
-                 E.unit(self.unit or "dimensionless"))),
+                 units=(self.unit or "dimensionless")),#),
                  name=self.name)
 
     @classmethod

--- a/lib9ml/python/nineml/user_layer/components/interface.py
+++ b/lib9ml/python/nineml/user_layer/components/interface.py
@@ -58,7 +58,7 @@ class Property(BaseULObject):
             value_element = E.array(" ".join(repr(x) for x in self.value))
         else:  # need to handle Function
             value_element = E.scalar(repr(self.value))
-        return E(Parameter.element_name,
+        return E(Property.element_name,
                  E.quantity(
 #                  E.value(   # this extra level of tags is pointless, no?
                  value_element,

--- a/lib9ml/python/nineml/user_layer/containers.py
+++ b/lib9ml/python/nineml/user_layer/containers.py
@@ -82,8 +82,8 @@ class Model(BaseULObject):
             http://docs.python.org/library/xml.etree.elementtree.html
             http://codespeak.net/lxml/
         """
-        assert element.tag == NINEML + 'nineml'
-        model = cls(element.attrib["name"])
+        assert element.tag == NINEML + 'NineML'
+        model = cls(element.get("name", 'Anonymous'))
         # Note that the components dict initially contains elementtree
         # elements, but is modified within Group.from_xml(), and at the end
         # contains Component instances.
@@ -172,7 +172,7 @@ class Group(BaseULObject):
     used as the node prototype within a population, allowing hierarchical
     structures.
     """
-    element_name = "group"
+    element_name = "Group"
     defining_attributes = ("name", "populations", "projections", "selections")
     children = ("populations", "projections", "selections")
 

--- a/lib9ml/python/nineml/user_layer/containers.py
+++ b/lib9ml/python/nineml/user_layer/containers.py
@@ -83,14 +83,15 @@ class Model(BaseULObject):
             http://codespeak.net/lxml/
         """
         assert element.tag == NINEML + 'NineML'
-        model = cls(element.get("name", 'Anonymous'))
+        model = cls(element.get("name"))
         # Note that the components dict initially contains elementtree
         # elements, but is modified within Group.from_xml(), and at the end
         # contains Component instances.
         components = {}
         groups = {}
         for child in element.findall(NINEML + BaseComponent.element_name):
-            components[child.attrib["name"]] = child
+            components[child.attrib["name"]] = BaseComponent.from_xml(child,
+                                                                      [])
         for child in element.findall(NINEML + Group.element_name):
             group = Group.from_xml(child, components, groups)
             model.groups[group.name] = group

--- a/lib9ml/python/nineml/user_layer/dynamics.py
+++ b/lib9ml/python/nineml/user_layer/dynamics.py
@@ -23,7 +23,7 @@ class SpikingNodeType(BaseDynamicsComponent):
     emit (and optionally receive) spikes.
 
     Should perhaps be called SpikingNodePrototype, since this is type +
-    parameters
+    properties
     """
     pass
 

--- a/lib9ml/python/nineml/user_layer/population.py
+++ b/lib9ml/python/nineml/user_layer/population.py
@@ -35,7 +35,7 @@ class Population(BaseULObject):
         if self.prototype:
             if isinstance(self.prototype, SpikingNodeType):
                 components.append(self.prototype)
-                components.extend(self.prototype.parameters.get_random_distributions())
+                components.extend(self.prototype.properties.get_random_distributions())
                 components.extend(self.prototype.initial_values.get_random_distributions())
             elif isinstance(self.prototype,
                             nineml.user_layer.containers.Group):
@@ -346,7 +346,7 @@ class Structure(BaseComponent):
 
     def to_csa(self):
         if self.is_csa:
-            return self.get_definition()  # e.g. lambda size: csa.random2d(size, *self.parameters) @IgnorePep8
+            return self.get_definition()  # e.g. lambda size: csa.random2d(size, *self.properties) @IgnorePep8
         else:
             raise Exception("Structure cannot be transformed to CSA geometry "
                             "function")

--- a/lib9ml/python/nineml/user_layer/population.py
+++ b/lib9ml/python/nineml/user_layer/population.py
@@ -13,7 +13,7 @@ class Population(BaseULObject):
     individual spiking nodes (neurons) or groups (motifs, microcircuits,
     columns, etc.)
     """
-    element_name = "population"
+    element_name = "Population"
     defining_attributes = ("name", "number", "prototype", "positions")
 
     def __init__(self, name, number, prototype, positions=None):
@@ -78,7 +78,7 @@ class PositionList(BaseULObject):
     explicit list of positions or a Structure instance that can be used to
     generate positions.
     """
-    element_name = "positions"
+    element_name = "Positions"
     defining_attributes = []
 
     def __init__(self, positions=[], structure=None):
@@ -221,21 +221,21 @@ class SelectionOperator(Operator):
 
 
 class Any(SelectionOperator):
-    element_name = "any"
+    element_name = "Any"
 
     def __str__(self):
         return "(" + ") or (".join(qstr(op) for op in self.operands) + ")"
 
 
 class All(SelectionOperator):
-    element_name = "all"
+    element_name = "All"
 
     def __str__(self):
         return "(" + ") and (".join(qstr(op) for op in self.operands) + ")"
 
 
 class Not(SelectionOperator):
-    element_name = "not"
+    element_name = "Not"
 
     def __init__(self, *operands):
         assert len(operands) == 1
@@ -249,14 +249,14 @@ class Comparison(Operator):
 
 
 class Eq(Comparison):
-    element_name = "equal"
+    element_name = "Equal"
 
     def __str__(self):
         return "(%s) == (%s)" % tuple(qstr(op) for op in self.operands)
 
 
 class In(Comparison):
-    element_name = "in"
+    element_name = "In"
 
     def __init__(self, item, sequence):
         Operator.__init__(self, item, sequence)
@@ -270,7 +270,7 @@ class Selection(BaseULObject):
     """
     A set of network nodes selected from existing populations within the Group.
     """
-    element_name = "set"
+    element_name = "Set"
     defining_attributes = ("name", "condition")
 
     def __init__(self, name, condition):
@@ -332,7 +332,7 @@ class Structure(BaseComponent):
     Component representing the structure of a network, e.g. 2D grid, random
     distribution within a sphere, etc.
     """
-    abstraction_layer_module = 'structure'
+    abstraction_layer_module = 'Structure'
 
     def generate_positions(self, number):
         """

--- a/lib9ml/python/nineml/user_layer/projection/__init__.py
+++ b/lib9ml/python/nineml/user_layer/projection/__init__.py
@@ -84,9 +84,9 @@ class Projection(BaseULObject):
                            "synaptic_response_ports", "connection_ports"]
         # to avoid infinite recursion, we do not include source or target in
         # the tests if they are Groups
-        if isinstance(self.source, Group):
+        if isinstance(self.source, nineml.user_layer.containers.Group):
             test_attributes.remove("source")
-        if isinstance(self.target, Group):
+        if isinstance(self.target, nineml.user_layer.containers.Group):
             test_attributes.remove("target")
         return reduce(and_, (getattr(self, attr) == getattr(other, attr)
                              for attr in test_attributes))
@@ -116,16 +116,16 @@ class Projection(BaseULObject):
     def from_xml(cls, element, components):
         check_tag(element, cls)
         return cls(name=element.attrib["name"],
-                   source=element.find(NINEML + "source").text,
-                   target=element.find(NINEML + "target").text,
+                   source=element.find(NINEML + "Source").text,
+                   target=element.find(NINEML + "Target").text,
                    rule=get_or_create_component(
-                                            element.find(NINEML + "rule").text,
+                                            element.find(NINEML + "Rule").text,
                                             ConnectionRule, components),
                    synaptic_response=get_or_create_component(
-                                        element.find(NINEML + "response").text,
+                                        element.find(NINEML + "Response").text,
                                         SynapseType, components),
                    connection_type=get_or_create_component(
-                                      element.find(NINEML + "plasticity").text,
+                                      element.find(NINEML + "Plasticity").text,
                                       ConnectionType, components),
                    synaptic_response_ports=tuple((pc.attrib["port1"],
                                                   pc.attrib["port2"])

--- a/lib9ml/python/nineml/user_layer/projection/__init__.py
+++ b/lib9ml/python/nineml/user_layer/projection/__init__.py
@@ -21,7 +21,7 @@ class Projection(BaseULObject):
     interpretation is that connections are made to all the populations within
     all the groups, recursively.
     """
-    element_name = "projection"
+    element_name = "Projection"
     defining_attributes = ("name", "source", "target", "rule",
                            "synaptic_response", "connection_type",
                            "synaptic_response_ports", "connection_ports")

--- a/lib9ml/python/nineml/user_layer/projection/cg_closure.py
+++ b/lib9ml/python/nineml/user_layer/projection/cg_closure.py
@@ -21,4 +21,4 @@ class CgClosure:
 
 def alConnectionRuleFromURI(uri):
     component = XMLReader.read(uri)
-    return CgClosure(component.parameters, component.connection_rule)
+    return CgClosure(component.properties, component.connection_rule)

--- a/lib9ml/python/nineml/user_layer/projection/grids.py
+++ b/lib9ml/python/nineml/user_layer/projection/grids.py
@@ -76,13 +76,13 @@ def createUnstructuredGrid(ul_population):
 
         if al_structure.name == 'grid_2d':
             fillOrder = ul_population.positions.structure.\
-                                                  parameters['fillOrder'].value
+                                                  properties['fillOrder'].value
             aspectRatioXY = ul_population.positions.structure.\
-                                              parameters['aspectRatioXY'].value
-            x0 = ul_population.positions.structure.parameters['x0'].value
-            y0 = ul_population.positions.structure.parameters['y0'].value
-            dx = ul_population.positions.structure.parameters['dx'].value
-            dy = ul_population.positions.structure.parameters['dy'].value
+                                              properties['aspectRatioXY'].value
+            x0 = ul_population.positions.structure.properties['x0'].value
+            y0 = ul_population.positions.structure.properties['y0'].value
+            dx = ul_population.positions.structure.properties['dx'].value
+            dy = ul_population.positions.structure.properties['dy'].value
 
             return Grid2D(x0, y0, dx, dy, ul_population.number)
 

--- a/lib9ml/python/nineml/user_layer/projection/utilities.py
+++ b/lib9ml/python/nineml/user_layer/projection/utilities.py
@@ -37,7 +37,7 @@ def connectionGeneratorFromProjection(projection, geometry):
 
     # Assembling a CG instantiation
     cgClosure = alConnectionRuleFromURI(rule.definition.url)
-    cg = cgClosure(rule.parameters)
+    cg = cgClosure(rule.properties)
     return cg
 
 

--- a/lib9ml/python/nineml/utility.py
+++ b/lib9ml/python/nineml/utility.py
@@ -8,6 +8,7 @@ analysis.
 
 from os.path import dirname, normpath, realpath, exists, join
 import sys
+import re
 
 import itertools
 import hashlib
@@ -451,7 +452,6 @@ class curry:
         return self.fun(*(self.pending + args), **kw)
 
 
-import re
 r = re.compile(r"""[a-zA-Z][a-zA-Z0-9_]*$""")
 
 
@@ -460,3 +460,11 @@ def ensure_valid_c_variable_name(tok):
         return
     else:
         raise NineMLRuntimeError("Invalid Token name: %s " % tok)
+
+valid_uri_re = re.compile(r'^(?:https?|file)://'  # http:// or https://
+                          r'(?:(?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+'
+                          r'(?:[A-Z]{2,6}\.?|[A-Z0-9-]{2,}\.?)|'  # domain
+                          r'localhost|'  # localhost
+                          r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
+                          r'(?::\d+)?'  # optional port
+                          r'(?:/?|[/?]\S+)$', re.IGNORECASE)

--- a/lib9ml/python/test/unit/nineml_test/abstraction_layer/visitors/base_test.py
+++ b/lib9ml/python/test/unit/nineml_test/abstraction_layer/visitors/base_test.py
@@ -18,7 +18,21 @@ class ActionVisitor_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_analogport(self):
+    def test_action_analogsendport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogreceiveport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogreduceport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
         # from nineml.abstraction_layer.visitors.base import ActionVisitor
@@ -53,7 +67,14 @@ class ActionVisitor_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_eventport(self):
+    def test_action_eventsendport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_eventreceiveport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
         # from nineml.abstraction_layer.visitors.base import ActionVisitor

--- a/lib9ml/python/test/unit/nineml_test/abstraction_layer/visitors/cloner_test.py
+++ b/lib9ml/python/test/unit/nineml_test/abstraction_layer/visitors/cloner_test.py
@@ -313,10 +313,24 @@ class ExpandPortDefinition_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_analogport(self):
+    def test_action_analogreceiveport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
-        # from nineml.abstraction_layer.visitors.cloner import ExpandPortDefinition
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogreduceport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogsendport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
@@ -348,7 +362,14 @@ class ExpandPortDefinition_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_eventport(self):
+    def test_action_eventreceiveport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.cloner import ExpandPortDefinition
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_eventsendport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
         # from nineml.abstraction_layer.visitors.cloner import ExpandPortDefinition
@@ -537,10 +558,24 @@ class ExpandAliasDefinition_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_analogport(self):
+    def test_action_analogsendport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
-        # from nineml.abstraction_layer.visitors.cloner import ExpandAliasDefinition
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogreceiveport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogreduceport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
@@ -572,10 +607,17 @@ class ExpandAliasDefinition_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_eventport(self):
+    def test_action_eventreceiveport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
-        # from nineml.abstraction_layer.visitors.cloner import ExpandAliasDefinition
+        # from nineml.abstraction_layer.visitors.cloner import ExpandPortDefinition
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_eventsendport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.cloner import ExpandPortDefinition
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
@@ -761,10 +803,24 @@ class RenameSymbol_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_analogport(self):
+    def test_action_analogreceiveport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
-        # from nineml.abstraction_layer.visitors.cloner import RenameSymbol
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogreduceport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_analogsendport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.base import ActionVisitor
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
@@ -796,10 +852,17 @@ class RenameSymbol_test(unittest.TestCase):
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 
-    def test_action_eventport(self):
+    def test_action_eventreceiveport(self):
         # Signature: name(self, port, **kwargs)
                 # No Docstring
-        # from nineml.abstraction_layer.visitors.cloner import RenameSymbol
+        # from nineml.abstraction_layer.visitors.cloner import ExpandPortDefinition
+        warnings.warn('Tests not implemented')
+        # raise NotImplementedError()
+
+    def test_action_eventsendport(self):
+        # Signature: name(self, port, **kwargs)
+                # No Docstring
+        # from nineml.abstraction_layer.visitors.cloner import ExpandPortDefinition
         warnings.warn('Tests not implemented')
         # raise NotImplementedError()
 

--- a/lib9ml/python/test/unit/test_userlayer.py
+++ b/lib9ml/python/test/unit/test_userlayer.py
@@ -5,7 +5,7 @@ Tests for the user_layer module
 
 import unittest
 from lxml import etree
-from nineml.user_layer.components.interface import Parameter
+from nineml.user_layer.components.interface import Property
 
 
 class ModelTest(unittest.TestCase):
@@ -51,10 +51,10 @@ class RandomDistributionTest(unittest.TestCase):
 class ParameterTest(unittest.TestCase):
 
     def test_xml_roundtrip(self):
-        p1 = Parameter("tau_m", 20.0, "mV")
+        p1 = Property("tau_m", 20.0, "mV")
         element = p1.to_xml()
         xml = etree.tostring(element, pretty_print=True)
-        p2 = Parameter.from_xml(element, [])
+        p2 = Property.from_xml(element, [])
         self.assertEqual(p1, p2)
 
 


### PR DESCRIPTION
Hi Andrew,

To match the syntax we agreed on in the meeting I have changed all the Analog/EventPort references to Analog/EventSend/Receive/ReducePorts in the XML loader and validation sections python library (just realised I also need to change the write side as well).

I have tested it with a sample 9ml file which contains at least one of each port and it loads without error. Probably need to test all the different validation rules but since these require unittests that haven't been written yet I have left this for now.

I will look into the write section in a few days but just thought I would open this request now in case you decide to do some work on it in the mean time.

Cheers,

Tom
